### PR TITLE
Update skillset / tech stack listing

### DIFF
--- a/mentorship/GUIDEBOOK.md
+++ b/mentorship/GUIDEBOOK.md
@@ -2,21 +2,25 @@
 
 ## **Background of Operation Code**
 
-Operation Code is on a mission to help the military community learn software development, enter the tech industry, and code the future! Our Mentorship Program connects members of the military community with tech industry professionals, for lifelong learning. Working together in our online community, you can select any programming skillset / tech stack of your choice, including:
+Operation Code is on a mission to help the military community learn software development, enter the tech industry, and code the future! Our Mentorship Program connects members of the military community with tech industry professionals for lifelong learning. Working together in our online community, you can select any programming skillset(s) / stack(s) of your choice, including:
 
-* Web Development
- * Ruby/Rails
- * Python
- * Node.js
- * Front-end Javascript
- * HTML/CSS
+* Web Development:
+  * Ruby on Rails
+  * Python
+  * Node.js
+  * Front-end Javascript
+  * HTML/CSS
  
-* Mobile Development
- * Java (Android)
- * Objective C and Swift (iOS)
+* Mobile Development:
+  * Android
+  * iOS
 
-* C, C++
-* C# / .NET
+* General Purpose:
+  * C, C++
+  * C# / .NET
+  * Java
+  * Objective C
+  * Swift
 
 ## **Statement of Purpose**
 


### PR DESCRIPTION
* correctly nested bullets (bullets that were intended to be nested had only a single leading space instead of two, resulting in no nesting)
* switched the mobile section to use platform instead of language (the languages previously listed are not used exclusively for mobile development)
* added a general purpose section (not entirely happy with this name since some bullets we have listed under web development, e.g. Ruby and Python, are also general-purpose languages)
* changed Ruby/Rails to Ruby on Rails (the more common and official styling...though alternatively perhaps this should just say Ruby)
* minor changes to the introductory paragraph that leads into this listing