### PR TITLE
Add first draft of new, concise mentorship README

### DIFF
--- a/mentorship/README.md
+++ b/mentorship/README.md
@@ -3,7 +3,7 @@
 The Operation Code mentorship program serves to guide our community of service members and their families in their journey of learning to build software and starting a successful career in the tech industry.
 
 # Programs
-We offer two main mentorship platforms - [Mentor Service Requests](#mentor-service-requests), and [Squads](#squads).
+Our main mentorship platform revolves around [Mentor Service Requests](#mentor-service-requests).  Mentors also provide ongoing informal/ad-hoc assistance by participating in discussions on our Slack Organization and the [Operation Code Community](https://community.operationcode.org/) Discourse forum.
 
 # Mentor Service Requests (1 on 1)
 Members can visit [http://op.co.de/mentor-request](http://op.co.de/mentor-request) to request a mentorship session.  Sessions are ~30 minute discussions between a mentee &  mentor via Slack, Voice Chat, or Video Chat.  A session should focus on a mentor helping a mentee with a specific task. Services offered are:
@@ -22,14 +22,6 @@ Operation Code’s Mentorship Coordination team will help pair mentees/mentors a
 
 After a mentorship session is fulfilled, mentees and mentors are free to continue the learning process on their own.  Mentees are also free to request a new mentorship session from another mentor or on a new topic.
 
-# Squads
-Squads are mentor-led small groups that work together towards a common goal over a longer period of time. Examples are building a small project together, learning a specific language, or working through an online-learning platform such as Codecademy or FreeCodeCamp.
 
-Squads will have:
-- A finite, measurable goal the squad can work towards.
-- At least one mentor serving as Squad Leader, and one additional mentor to assist
-- A minimum/maximum number of mentees
-- A weekly schedule of activities for the squad (office hours, study sessions, exercises, etc.)
-- An end date or success condition for the squad
-
-Mentors can visit [https://op.co.de/squad-request](https://op.co.de/squad-request) to set up a squad.
+# Additional Information
+Please refer to the [Mentor Guidebook](https://github.com/OperationCode/documents/blob/master/mentorship/GUIDEBOOK.md) for more details on how to best work together and build a successful mentor/mentee relationship.

--- a/mentorship/README.md
+++ b/mentorship/README.md
@@ -2,58 +2,34 @@
 
 The Operation Code mentorship program serves to guide our community of service members and their families in their journey of learning to build software and starting a successful career in the tech industry.
 
-# Onboarding
-
-To join Operation Code as a mentor please sign up at https://operationcode.org/join. You'll receive an email inviting you to our slack community. Once you join introduce yourself, to include what technologies you're familiar with. You should also receive an invite to our mentor channel. 
-
-Once you're in slack please fill out http://op.co.de/mentor-enrollment. You should then receive an invite to our mentors-internal room.
-
 # Programs
+We offer two main mentorship platforms - [Mentor Service Requests](#mentor-service-requests), and [Squads](#squads).
 
-## 1 on 1
+# Mentor Service Requests (1 on 1)
+Members can visit [http://op.co.de/mentor-request](http://op.co.de/mentor-request) to request a mentorship session.  Sessions are ~30 minute discussions between a mentee &  mentor via Slack, Voice Chat, or Video Chat.  A session should focus on a mentor helping a mentee with a specific task. Services offered are:
 
-When you sign up as a mentor you'll identify a few key areas you're able to help in. We'll use these areas to match you up with members who are requesting a mentor. When a memeber requests a mentor they'll be matched with one of our mentors. If you match the areas of interest for the mentee you'll be paired up and notified. 
+- General guidance (any topic)
+- Pair programming
+- Code review
+- Mock interviews
+- Resume review
 
-Please refer to the [Mentor Guidebook](https://github.com/OperationCode/documents/blob/master/mentorship/GUIDEBOOK.md) for more details on how to work with your mentee.
+Mentors can fill out [http://op.co.de/mentor-enrollment](http://op.co.de/mentor-enrollment) to volunteer as a mentor.
 
-## Squads
+Mentors will watch [http://op.co.de/mentor-requests](http://op.co.de/mentor-requests) for mentee requests.  Any mentor can self-assign to an outstanding mentorship request on a first-come, first serve basis.   Mentors should mark the Airtable spreadsheet with their name as the  Mentor Assigned, add notes, and mark the request as ‘Fulfilled’ after the session takes place (or after a reasonable number of communication attempts).
 
-The squad framework is a way for Operation Code members to be grouped with mentors in order to work towards a common goal.
-As a mentor you can either lead or help support a squad. 
-If you see a squad in progress and would like to join notify the squad leader for more information.
+Operation Code’s Mentorship Coordination team will help pair mentees/mentors and notify other mentors via Slack to fulfill outstanding requests.
 
-### Starting A Squad
+After a mentorship session is fulfilled, mentees and mentors are free to continue the learning process on their own.  Mentees are also free to request a new mentorship session from another mentor or on a new topic.
 
-To start a squad you will need to identify a few items first. 
+# Squads
+Squads are mentor-led small groups that work together towards a common goal over a longer period of time. Examples are building a small project together, learning a specific language, or working through an online-learning platform such as Codecademy or FreeCodeCamp.
 
-At a minimum you will need:
-* A theme for the squad. This should be a finite, measurable goal the squad can work towards.
-* At least 1 additional mentor to assist in the squad
-* A minimum number of members required to start the squad
-* A maximum number of members in the squad
-* A minimum skill level (beginner, intermediate, advanced)
-* Can a member join the squad after it has started?
-* A weekly schedule of activities for the squad. This can be as simple as office hours, or as extensive as project deadlines
-* An end date or condition for the squad
+Squads will have:
+- A finite, measurable goal the squad can work towards.
+- At least one mentor serving as Squad Leader, and one additional mentor to assist
+- A minimum/maximum number of mentees
+- A weekly schedule of activities for the squad (office hours, study sessions, exercises, etc.)
+- An end date or success condition for the squad
 
-When you've gathered these requirements please fill out the following form:
-
-https://op.co.de/squad-request
-
-Once these items have been defined and the form has been filled out you can start promoting your squad to our general members. 
-When you reach your minimum members you can set a start date on your squad.
-
-### Running a squad
-
-While your squad is running be sure to:
-* Stick to the schedule
-* Keep seeking feedback from your squad mates
-* If you're the squad leader reach out to your fellow mentors at least twice a month
-* If you're the squad leader reach out to a mentorship staff member at least twice a month
-
-### Ending a squad
-
-When your squads goal has been met the following actions should be completed:
-* Notify mentorship staff members
-* Write up a brief overview of what the squad completed and share it with #general
-
+Mentors can visit [https://op.co.de/squad-request](https://op.co.de/squad-request) to set up a squad.


### PR DESCRIPTION
@hollomancer @Exupery @rickr 

#### User Story: 
"As a prospective or new mentor/mentee, I can quickly read a one-page document that explains how Operation Code's Mentorship program works, and how I can start to participate."

For some time, the mentorship team has talked about creating a sharable, concise, one-page, ELI5 Mentorship doc that sums up what we're currently doing with the program in easy-to-read manner.  The Mentorship README could be a good candidate for this.

The [Guidebook](https://github.com/jjhampton/documents/blob/master/mentorship/GUIDEBOOK.md) has some great content, but it's a bit outdated, and worse, it's a 5-10 page novel.  We need something we can share with prospective/new mentors that sums it all up, and allows people to read it and then jump right in.  

I'm often asked by people on Slack interested in helping out, and I don't always have time to type out exactly how the current process works (mentor service requests, squads, etc).  Sharing a link like this can help with that.

Main goals: 
* Sum up how Mentor Service Requests work w/ Airtable
* Sum up the general idea behind Squads (this can be expanded to a separate page if we move forward with the idea of repurposing the Squads behind one of the platforms like Codecademy, FCC, etc.)

Open to any feedback.

